### PR TITLE
Removing dependencies that cause HR deployment to fail in the BBC env

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.9.0
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.10.14
-digest: sha256:0ab644a92fd39f0ea88c8784c503b413815641091e55147e46d969cd6d67e855
-generated: "2021-03-06T20:02:09.909589826+01:00"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-  - name: redis
-    version: "^10.8.2"
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: redis.enabled
-  - name: postgresql
-    version: "^8.10.14"
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: postgresql.enabled


### PR DESCRIPTION
I didn't remove all the refs to the requirements in the chart in order to minimize the diffs with the upstream chart.