### PR TITLE
Better hook config + add missing datadog labels and annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -544,7 +544,22 @@ ad.datadoghq.com/redash-server.init_configs: '[{}]'
 {{- end }}
 
 {{- define "datadog.annotations.adhocworker" }}
-ad.datadoghq.com/redash-adhocworker.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+ad.datadoghq.com/redash-adhocworker.logs: >-
+  [{
+
+    "source": "redash",
+    "service": "{{ $.Release.Name }}",
+    "log_processing_rules": [{
+      "type": "exclude_at_match",
+      "name": "exclude_healthcheck",
+      "pattern" : "worker_healthcheck"
+    },
+    {
+      "type": "exclude_at_match",
+      "name": "exclude_info",
+      "pattern" : "info"
+    }]
+  }]
 ad.datadoghq.com/redash-adhocworker.init_configs: '[{}]'
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -532,6 +532,27 @@ app: {{ .Release.Name }}
 component: database
 {{- end -}}
 
+{{- define "datadog.labels" }}
+tags.datadoghq.com/service: {{ .Release.Name | lower | quote }}
+tags.datadoghq.com/version: {{ .Values.image.tag | quote }}
+team: team_dbre
+{{- end }}
+
+{{- define "datadog.annotations.server" }}
+ad.datadoghq.com/redash-server.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+ad.datadoghq.com/redash-server.init_configs: '[{}]'
+{{- end }}
+
+{{- define "datadog.annotations.adhocworker" }}
+ad.datadoghq.com/redash-adhocworker.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+ad.datadoghq.com/redash-adhocworker.init_configs: '[{}]'
+{{- end }}
+
+{{- define "datadog.annotations.scheduledworker" }}
+ad.datadoghq.com/redash-scheduledworker.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+ad.datadoghq.com/redash-scheduledworker.init_configs: '[{}]'
+{{- end }}
+
 {{/*
 Create the name of the service account to use
 */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -546,7 +546,6 @@ ad.datadoghq.com/redash-server.init_configs: '[{}]'
 {{- define "datadog.annotations.adhocworker" }}
 ad.datadoghq.com/redash-adhocworker.logs: >-
   [{
-
     "source": "redash",
     "service": "{{ $.Release.Name }}",
     "log_processing_rules": [{

--- a/templates/adhocworker-deployment.yaml
+++ b/templates/adhocworker-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "redash.adhocWorker.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
+    {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: adhocworker
 spec:
   replicas: {{ .Values.adhocWorker.replicaCount }}
@@ -15,9 +16,11 @@ spec:
     metadata:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- include "datadog.labels" . | indent 8 }}
         app.kubernetes.io/component: adhocworker
-      {{- if .Values.adhocWorker.podAnnotations }}
       annotations:
+      {{- include "datadog.annotations.adhocworker" . | indent 8 }}
+      {{- if .Values.adhocWorker.podAnnotations }}
       {{ toYaml .Values.adhocWorker.podAnnotations | nindent 8 }}
       {{- end }}
     spec:

--- a/templates/hook-config-job.yaml
+++ b/templates/hook-config-job.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "{{ .Release.Name }}-config"
   labels:
 {{- include "redash.labels" . | nindent 4 }}
+{{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: config
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
@@ -16,6 +17,7 @@ spec:
       name: "{{ .Release.Name }}"
       labels:
 {{- include "redash.selectorLabels" . | nindent 8 }}
+{{- include "datadog.labels" . | indent 8 }}
       annotations: {{ toYaml .Values.hookConfigJob.podAnnotations | nindent 8 }}
     spec:
       volumes:

--- a/templates/hook-config-job.yaml
+++ b/templates/hook-config-job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "30"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/templates/hook-config-job.yaml
+++ b/templates/hook-config-job.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: config
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-weight": "30"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:

--- a/templates/hook-install-job.yaml
+++ b/templates/hook-install-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ .Release.Name }}-install"
   labels:
     {{- include "redash.labels" . | nindent 4 }}
+    {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: install
   annotations:
     # This is what defines this resource as a hook.
@@ -17,6 +18,7 @@ spec:
       name: "{{ .Release.Name }}"
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- include "datadog.labels" . | indent 8 }}
       {{- if .Values.hookInstallJob.podAnnotations }}
       annotations:
       {{ toYaml .Values.hookInstallJob.podAnnotations | nindent 8 }}

--- a/templates/hook-upgrade-job.yaml
+++ b/templates/hook-upgrade-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ .Release.Name }}-upgrade"
   labels:
     {{- include "redash.labels" . | nindent 4 }}
+    {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: upgrade
   annotations:
     # This is what defines this resource as a hook.
@@ -17,6 +18,7 @@ spec:
       name: "{{ .Release.Name }}"
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- include "datadog.labels" . | indent 8 }}
       {{- if .Values.hookUpgradeJob.podAnnotations }}
       annotations:
       {{ toYaml .Values.hookUpgradeJob.podAnnotations | nindent 8 }}

--- a/templates/scheduledworker-deployment.yaml
+++ b/templates/scheduledworker-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "redash.scheduledWorker.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
+    {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: scheduledworker
 spec:
   # Must stay at 1, if several scheduler are spawn there will be a conflict with an already active rqscheduler found with the same key in redis
@@ -16,9 +17,11 @@ spec:
     metadata:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- include "datadog.labels" . | indent 8 }}
         app.kubernetes.io/component: scheduledworker
-      {{- if .Values.scheduledWorker.podAnnotations }}
       annotations:
+      {{- include "datadog.annotations.scheduledworker" . | indent 8 }}
+      {{- if .Values.scheduledWorker.podAnnotations }}
       {{ toYaml .Values.scheduledWorker.podAnnotations | nindent 8 }}
       {{- end }}
     spec:

--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "redash.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
+    {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: server
 spec:
   replicas: {{ .Values.server.replicaCount }}
@@ -15,8 +16,10 @@ spec:
     metadata:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- include "datadog.labels" . | indent 8 }}
         app.kubernetes.io/component: server
       annotations:
+      {{- include "datadog.annotations.server" . | indent 8 }}
       {{- if .Values.server.podAnnotations -}}
       {{ toYaml .Values.server.podAnnotations | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**1st patch**: `hook-delete-policy`
=> to avoid the issue that we got on prod-pmp (previous job failed, stayed in K8S, and next HR update failed, because `jobs.batch "redash-config" already exists`, which required manual deletion of the job to fix, all details in this [slack thread](https://blablacar.slack.com/archives/G4G382620/p1674462623350249))
cf: https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies

Also (not related, but boyscout): **2nd patch** to also run the hook on rollback.