### PR TITLE
feat: make Redis authentication actionable through values

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -100,14 +100,21 @@ Shared environment block used across each component.
   value: "{{ .Values.postgresql.postgresqlDatabase }}"
 {{- end }}
 {{- if not .Values.redis.enabled }}
-- name: REDASH_REDIS_URL
-  {{- if .Values.externalRedisSecret }}
+- name: REDASH_REDIS_PASSWORD
+  {{- if .Values.externalRedis.auth.enabled }}
   valueFrom:
     secretKeyRef:
-      {{- .Values.externalRedisSecret | toYaml | nindent 6 }}
+      name: {{ .Values.externalRedis.auth.secretName | quote }}
+      key: {{ .Values.externalRedis.auth.secretKey }}
   {{- else }}
-  value: {{ default "" .Values.externalRedis | quote }}
+  value: ""
   {{- end }}
+- name: REDASH_REDIS_HOSTNAME
+  value: {{ .Values.externalRedis.host }}
+- name: REDASH_REDIS_PORT
+  value: "{{ .Values.externalRedis.port }}"
+- name: REDASH_REDIS_DB
+  value: {{ .Values.externalRedis.database }}
 {{- else }}
 - name: REDASH_REDIS_PASSWORD
   valueFrom:

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -83,9 +83,10 @@ data:
     else
       echo "Using external postgresql database"
     fi
-    if [ -z "$REDASH_REDIS_URL" ]; then
-      export REDASH_REDIS_URL=redis://:${REDASH_REDIS_PASSWORD}@${REDASH_REDIS_HOSTNAME}:${REDASH_REDIS_PORT}/${REDASH_REDIS_DB}
-      echo "Using Redis: redis://:******@${REDASH_REDIS_HOSTNAME}:${REDASH_REDIS_PORT}/${REDASH_REDIS_DB}"
+    if [ -z "$REDASH_REDIS_PASSWORD" ]; then
+      echo "Using authentication to Redis"
     else
-      echo "Using external redis database"
+      echo "Not using authentication to Redis"
     fi
+    export REDASH_REDIS_URL=redis://:${REDASH_REDIS_PASSWORD:-}@${REDASH_REDIS_HOSTNAME}:${REDASH_REDIS_PORT}/${REDASH_REDIS_DB}
+    echo "Using Redis: redis://:******@${REDASH_REDIS_HOSTNAME}:${REDASH_REDIS_PORT}/${REDASH_REDIS_DB}"

--- a/values.yaml
+++ b/values.yaml
@@ -510,7 +510,7 @@ externalPostgreSQLSecret:
   # name: redash-postgres
   # key: connectionString
 
-# envSecretName -- DEPRECIATED, use externalPostgreSQLSecret/externalRedisSecret instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
+# envSecretName -- DEPRECIATED, use externalPostgreSQLSecret/externalRedis.auth.secretName instead. Contents of this secret will be loaded as environment variables into the container. Useful e.g. to set to set PostgreSQL password in externalPostgreSQL parameter: postgresql://user:$(POSTGRESQL_PASSWORD)@host:5432/database [ref](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config)
 # envSecretName:
 
 ## Configuration values for the postgresql dependency. This PostgreSQL instance is used by default for all Redash state storage [ref](https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md)
@@ -543,11 +543,13 @@ postgresql:
 
 # externalRedis -- External Redis configuration. To use an external Redis instead of the automatically deployed redis chart: set redis.enabled to false then uncomment and configure the externalRedis connection URL (e.g. redis://user:pass@host:6379/database).
 externalRedis:
-# externalRedisSecret -- Read external Redis configuration from a secret. This should point at a secret file with a single key which specifyies the connection string.
-externalRedisSecret:
-  {}
-  # name: redash-redis
-  # key: connectionString
+  host: ""      # The name of the Kube service you created elsewhere, pointing to your Redis master.
+  database: ""  # Stays empty in the case of MemoryStore
+  port: 6379
+  auth:
+    enabled: false  # Whether or not to use authentication
+    secretName: ""  # Name of the secret where the external Redis's auth string is to be found
+    secretKey: "redisAuthString"
 
 ## Configuration values for the redis dependency. This Redis instance is used by default for caching and temporary storage [ref](https://github.com/kubernetes/charts/blob/master/stable/redis/README.md)
 redis:


### PR DESCRIPTION
This PR makes Redis authentication actionable through values.

Part of DBRE-3381

## Detail

I'm changing the `values` interface of the chart, to have more comprehensive configuration options when an external Redis is used. I chose to subdivide the `.Values.redis` block into two subblocks: an `internalRedis` and an `externalRedis` block, to be used when `redis.useInternalRedis` is set to `false`.

## TODO

-[ ] Update Chart
-[ ] Update Chart `README.md`
-[ ] Update Confluence documentation
