### PR TITLE
[DBRE-3348] move Istio annotations to labels on hook and upgrade jobs

### DIFF
--- a/templates/hook-install-job.yaml
+++ b/templates/hook-install-job.yaml
@@ -3,6 +3,8 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-install"
   labels:
+    # Disable Istio side-car preventing job to finish properly
+    sidecar.istio.io/inject: "false"
     {{- include "redash.labels" . | nindent 4 }}
     {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: install

--- a/templates/hook-install-job.yaml
+++ b/templates/hook-install-job.yaml
@@ -3,8 +3,6 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-install"
   labels:
-    # Disable Istio side-car preventing job to finish properly
-    sidecar.istio.io/inject: "false"
     {{- include "redash.labels" . | nindent 4 }}
     {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: install
@@ -19,6 +17,8 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
+        # Disable Istio side-car preventing job to finish properly
+        sidecar.istio.io/inject: "false"
         {{- include "redash.selectorLabels" . | nindent 8 }}
         {{- include "datadog.labels" . | indent 8 }}
       {{- if .Values.hookInstallJob.podAnnotations }}

--- a/templates/hook-upgrade-job.yaml
+++ b/templates/hook-upgrade-job.yaml
@@ -3,6 +3,8 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-upgrade"
   labels:
+    # Disable Istio side-car preventing job to finish properly
+    sidecar.istio.io/inject: "false"
     {{- include "redash.labels" . | nindent 4 }}
     {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: upgrade

--- a/templates/hook-upgrade-job.yaml
+++ b/templates/hook-upgrade-job.yaml
@@ -3,8 +3,6 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-upgrade"
   labels:
-    # Disable Istio side-car preventing job to finish properly
-    sidecar.istio.io/inject: "false"
     {{- include "redash.labels" . | nindent 4 }}
     {{- include "datadog.labels" . | indent 4 }}
     app.kubernetes.io/component: upgrade
@@ -19,6 +17,8 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
+        # Disable Istio side-car preventing job to finish properly
+        sidecar.istio.io/inject: "false"
         {{- include "redash.selectorLabels" . | nindent 8 }}
         {{- include "datadog.labels" . | indent 8 }}
       {{- if .Values.hookUpgradeJob.podAnnotations }}


### PR DESCRIPTION
Istio is enabled on all redash pods server/workers since we have set authorization policy. Still for the upgrade and install job istio side-car prevent the job to finish properly. Until now it was set in the hr via the podAnnotations specs. The isitio annotation is deprecated (DBRE-3285) and we should set it as label. So in this PR we just keep it simple with 2 lines add the label in the chart directly