### PR TITLE
[DBRE-3747] set long query auto cancel (180s)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -175,7 +175,7 @@ redash:
   # redash.disabledQueryRunners -- `REDASH_DISABLED_QUERY_RUNNERS` value. Defaults to ``.
   disabledQueryRunners:
   # redash.adhocQueryTimeLimit -- `REDASH_ADHOC_QUERY_TIME_LIMIT` value. Defaults to `None`.
-  adhocQueryTimeLimit: 4
+  adhocQueryTimeLimit: 180
   # redash.enabledDestinations -- `REDASH_ENABLED_DESTINATIONS` value. Defaults to `”,”.join(default_destinations)`.
   enabledDestinations:
   # redash.additionalDestinations -- `REDASH_ADDITIONAL_DESTINATIONS` value. Defaults to ``.

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,8 @@ redash:
   # redash.statsdUseTags -- `REDASH_STATSD_USE_TAGS` value. Defaults to `false`. Whether to use tags in statsd metrics (influxdb’s format).
   statsdUseTags:
   # redash.queryResultsCleanupEnabled -- `REDASH_QUERY_RESULTS_CLEANUP_ENABLED` value. Defaults to `true`.
+  scheduledQueryTimeLimit: 4
+  adhocQueryTimeLimit : 4
   queryResultsCleanupEnabled:
   # redash.queryResultsCleanupCount -- `REDASH_QUERY_RESULTS_CLEANUP_COUNT` value. Defaults to `100`.
   queryResultsCleanupCount:

--- a/values.yaml
+++ b/values.yaml
@@ -79,8 +79,6 @@ redash:
   # redash.statsdUseTags -- `REDASH_STATSD_USE_TAGS` value. Defaults to `false`. Whether to use tags in statsd metrics (influxdb’s format).
   statsdUseTags:
   # redash.queryResultsCleanupEnabled -- `REDASH_QUERY_RESULTS_CLEANUP_ENABLED` value. Defaults to `true`.
-  scheduledQueryTimeLimit: 4
-  adhocQueryTimeLimit : 4
   queryResultsCleanupEnabled:
   # redash.queryResultsCleanupCount -- `REDASH_QUERY_RESULTS_CLEANUP_COUNT` value. Defaults to `100`.
   queryResultsCleanupCount:
@@ -177,7 +175,7 @@ redash:
   # redash.disabledQueryRunners -- `REDASH_DISABLED_QUERY_RUNNERS` value. Defaults to ``.
   disabledQueryRunners:
   # redash.adhocQueryTimeLimit -- `REDASH_ADHOC_QUERY_TIME_LIMIT` value. Defaults to `None`.
-  adhocQueryTimeLimit:
+  adhocQueryTimeLimit: 4
   # redash.enabledDestinations -- `REDASH_ENABLED_DESTINATIONS` value. Defaults to `”,”.join(default_destinations)`.
   enabledDestinations:
   # redash.additionalDestinations -- `REDASH_ADDITIONAL_DESTINATIONS` value. Defaults to ``.


### PR DESCRIPTION
Exemple:
<img width="772" alt="image" src="https://github.com/blablacar/redash-contrib-helm-chart/assets/72397534/2e9dda99-2726-483a-af89-b88a8911aff8">
And below it's ok 
<img width="978" alt="image" src="https://github.com/blablacar/redash-contrib-helm-chart/assets/72397534/c0b2aa4d-ca7a-4322-bd41-c0a972e093b2">
