### PR TITLE
Chart 1.0.0: bbc fork v2, rebased from upstream (2024-June)

### DIFF
--- a/charts/redash/requirements.lock
+++ b/charts/redash/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.1.3
-- name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.5
-digest: sha256:151965ff63f41c38de182793b57c890da72de2e699c7f69a98e179cfa07ece09
-generated: "2024-04-24T09:02:42.314748+03:00"

--- a/charts/redash/requirements.yaml
+++ b/charts/redash/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-  - name: redis
-    version: "^19.1.0"
-    repository: oci://registry-1.docker.io/bitnamicharts
-    condition: redis.enabled
-  - name: postgresql
-    version: "^15.2.0"
-    repository: oci://registry-1.docker.io/bitnamicharts
-    condition: postgresql.enabled

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -534,6 +534,8 @@ Selector labels
 {{- define "redash.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "redash.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app: {{ .Release.Name }}
+component: database
 {{- end -}}
 
 {{/*

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Shared environment block used across each component.
   value: {{ .Values.postgresql.auth.database | quote }}
 {{- end -}}
 {{- if not .Values.redis.enabled }}
-{{- if not .Values.redash.selfManagedSecrets -}}
+{{- if not .Values.redash.selfManagedSecrets }}
 - name: REDASH_REDIS_URL
   {{- with .Values.externalRedisSecret }}
   valueFrom:
@@ -126,11 +126,11 @@ Shared environment block used across each component.
   value: {{ .Values.redis.master.service.ports.redis | quote }}
 - name: REDASH_REDIS_NAME
   value: {{ .Values.redis.database | quote }}
-{{ end -}}
-{{ range $key, $value := .Values.env -}}
+{{- end }}
+{{- range $key, $value := .Values.env }}
 - name: {{ $key }}
   value: {{ $value | quote }}
-{{ end -}}
+{{- end }}
 ## Start primary Redash configuration
 {{- if not .Values.redash.selfManagedSecrets }}
 {{- if or .Values.redash.secretKey .Values.redash.existingSecret }}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -71,6 +71,24 @@ Get the secret name.
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Get the hostname from the postgresql connection string
+Example: the input should be similar to:
+    postgresql://redash:$(POSTGRESQL_PASSWORD)@my-pg-host-for-redash/redash
+And the output will be:
+    my-pg-host-for-redash
+*/}}
+{{- define "redash.externalPostgresql.hostname" -}}
+{{ mustRegexReplaceAll ".*@([^/:]+)[/:].*" .Values.externalPostgreSQL "${1}" }}
+{{- end -}}
+
+{{/* same than Postgres above */}}
+{{- define "redash.externalRedis.hostname" -}}
+{{ mustRegexReplaceAll ".*@([^/:]+)[/:].*" .Values.externalRedis "${1}" }}
+{{- end -}}
+
+
 {{/*
 Shared environment block used across each component.
 */}}

--- a/charts/redash/templates/_helpers.tpl
+++ b/charts/redash/templates/_helpers.tpl
@@ -523,6 +523,9 @@ app.kubernetes.io/component: {{ . }}worker
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ tpl (toYaml .Values.commonLabels) . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/redash/templates/authorizationpolicy.yaml
+++ b/charts/redash/templates/authorizationpolicy.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - "cluster.local/ns/infra/sa/uberproxy"
+              # The config Job needs to call Redash's API
+              - "cluster.local/ns/{{ .Release.Namespace }}/sa/{{ include "redash.serviceAccountName" . }}"

--- a/charts/redash/templates/configmap-datasources.yaml
+++ b/charts/redash/templates/configmap-datasources.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.config -}}
+apiVersion: v1
+data:
+  datasources.yaml: |
+{{ toYaml .Values.config.datasources | indent 4 }}
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-datasources
+{{- end -}}

--- a/charts/redash/templates/configmap-groups.yaml
+++ b/charts/redash/templates/configmap-groups.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.config -}}
+apiVersion: v1
+data:
+  groups.yaml: |
+{{ toYaml .Values.config.groups | indent 4 }}
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-groups
+{{- end -}}

--- a/charts/redash/templates/hook-config-job.yaml
+++ b/charts/redash/templates/hook-config-job.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.config -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-config"
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+  annotations:
+    # This is what defines this resource as a hook.
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "30"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- if .Values.hookConfigJob.podLabels }}
+        {{- tpl (toYaml .Values.hookConfigJob.podLabels) $ | nindent 8 }}
+        {{- end }}
+      {{- with .Values.hookConfigJob.podAnnotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      volumes:
+        - configMap:
+            name: {{ .Release.Name }}-datasources
+          name: {{ .Release.Name }}-datasources
+        - configMap:
+            name: {{ .Release.Name }}-groups
+          name: {{ .Release.Name }}-groups
+      serviceAccountName: {{ include "redash.serviceAccountName" . }}
+      restartPolicy: Never
+      securityContext: {{ toYaml .Values.hookConfigJob.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ include "redash.name" . }}-config
+        securityContext: {{ toYaml .Values.hookConfigJob.securityContext | nindent 10 }}
+        image: "{{ .Values.hookConfigJob.image.repository }}:{{ .Values.hookConfigJob.image.tag }}"
+        imagePullPolicy: {{ .Values.hookConfigJob.image.pullPolicy }}
+        command: ["envoy-preflight", "python3", "redash-config-gitops.py"]
+        args:
+          - --host=http://{{ .Release.Name }}
+          - --apikey=$(APIKEY)
+        volumeMounts:
+        - name: {{ .Release.Name }}-datasources
+          mountPath: /config/datasources
+        - name: {{ .Release.Name }}-groups
+          mountPath: /config/groups
+        env:
+          - name: APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}
+                key: apikey
+          # variables below are required by envoy-preflight (to shut down the Envoy proxy once the job completes)
+          - name: ENVOY_ADMIN_API
+            value: "http://127.0.0.1:15000/"
+          - name: ISTIO_QUIT_API
+            value: "http://127.0.0.1:15000/"
+        envFrom:
+        - secretRef:
+            name: {{ .Release.Name }}-datasources
+        resources: {{ toYaml .Values.hookConfigJob.resources | nindent 10 }}
+{{- end -}}

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -15,7 +15,11 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}"
-      labels: {{ include "redash.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        {{- with .Values.migrations.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- with .Values.migrations.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redash/templates/hook-migrations-job.yaml
+++ b/charts/redash/templates/hook-migrations-job.yaml
@@ -21,7 +21,7 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.migrations.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/redash/templates/istio-sidecar.yaml
+++ b/charts/redash/templates/istio-sidecar.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  workloadSelector:
+    labels: {{ include "redash.selectorLabels" . | nindent 6 }}
+  outboundTrafficPolicy:
+    mode: {{ .Values.istio.outboundTrafficPolicy }}
+  ingress:
+  - defaultEndpoint: 127.0.0.1:{{ .Values.server.httpPort }}
+    port:
+      name: http
+      number: {{ .Values.server.httpPort }}
+      protocol: HTTP
+  egress:
+  - hosts:
+    # GKE/K8S system:
+    - "istio-system/metadata.google.internal"
+    - "istio-system/metadata.google.internal."
+    # Redash "system":
+    - "./{{ include "redash.externalPostgresql.hostname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "./{{ include "redash.externalRedis.hostname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "./{{ include "redash.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"    # this is the name of the HTTP service, useful for the config job to connect to the API
+    # SSO:
+    - "*/app-eu.onelogin.com"
+    - "*/blablacar.onelogin.com"
+    {{- if .Values.config }}
+    # The datasources (in the values, the host value should be a "short name", ex: mariadb-main.v3)
+    {{- range .Values.config.datasources }}
+    - "*/{{- .options.host }}.svc.cluster.local"
+    {{- end }}
+    {{- end }}

--- a/charts/redash/templates/scheduler-deployment.yaml
+++ b/charts/redash/templates/scheduler-deployment.yaml
@@ -21,8 +21,8 @@ spec:
         {{- with .Values.scheduler.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- if .Values.scheduler.podAnnotations }}
-      annotations: {{ toYaml .Values.scheduler.podAnnotations | nindent 8 }}
+      {{- with .Values.scheduler.podAnnotations }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with .Values.imagePullSecrets -}}

--- a/charts/redash/templates/server-deployment.yaml
+++ b/charts/redash/templates/server-deployment.yaml
@@ -16,11 +16,11 @@ spec:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: server
-        {{- if .Values.server.podLabels }}
-        {{- tpl (toYaml .Values.server.podLabels) $ | nindent 8 }}
+        {{- with .Values.server.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.server.podAnnotations }}
-      annotations: {{ toYaml . | nindent 8 }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with .Values.imagePullSecrets -}}

--- a/charts/redash/templates/worker-deployment.yaml
+++ b/charts/redash/templates/worker-deployment.yaml
@@ -13,12 +13,13 @@ spec:
     matchLabels: {{ include "redash.selectorLabels" $context | nindent 6 }}
   template:
     metadata:
-      labels: {{ include "redash.selectorLabels" $context | nindent 8 }}
-      {{- if $workerConfig.podLabels }}
-      {{ tpl (toYaml $workerConfig.podLabels) $ | nindent 8 }}
-      {{- end }}
-      {{- with $workerConfig.podAnnotations -}}
-      annotations: {{ toYaml . | nindent 8 }}
+      labels:
+        {{- include "redash.selectorLabels" $context | nindent 8 }}
+        {{- with $workerConfig.podLabels }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with $workerConfig.podAnnotations }}
+      annotations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
     spec:
       {{ with $.Values.imagePullSecrets -}}

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -354,6 +354,8 @@ server:
   podAnnotations:
     ad.datadoghq.com/redash-server.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
     ad.datadoghq.com/redash-server.init_configs: '[{}]'
+    checksum/configmap-datasources: '{{ include (print $.Template.BasePath "/configmap-datasources.yaml") $ | sha256sum }}'
+    checksum/configmap-groups: '{{ include (print $.Template.BasePath "/configmap-groups.yaml") $ | sha256sum }}'
 
   # server.podLabels -- Labels for server pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
   podLabels:
@@ -668,3 +670,62 @@ extraObjects: []
 #       secretsManagerSecretRef:
 #         secretId: redash-postgres-prod
 #         versionId: 00000000-1111-2222-3333-444444444444
+
+
+
+# Configuration for hook-config-job
+hookConfigJob:
+  image:
+    repository: eu.gcr.io/bbc-registry/redash-config
+    tag: 1.20240416100708.0-shaf2292497
+    pullPolicy: IfNotPresent
+  # hookConfigJob.podAnnotations -- Annotations for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+  podAnnotations: {}
+  podLabels:
+    tags.datadoghq.com/service: "{{ .Release.Name | lower }}"
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    team: dbre
+  podSecurityContext: {}  # TODO: set a USER in the image's Dockerfile & put runAsNonRoot: true here
+  securityContext: {}
+  resources:
+    limits:
+      memory: 300Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
+# "Infra-as-code" configuration of redash-internals (datasources, groups, permissions)
+#config:
+  #datasources:
+    ########### mariadb example ###########
+    #- name: preprod/dbre/mariadb-test
+      #type: mysql
+      #options:
+        #host: mariadb-test.dbre
+        #port: 3306
+        #user: redash_rd
+        #passwd: MARIADB_TEST_DBRE_PWD # name of key Ref in redash secret
+        #db: mysql
+    ########### postegresql example ###########
+    #- name: preprod/dbre/pg-test
+      #type: pg
+      #options:
+        #host: pg-test.dbre
+        #port: 5432
+        #user: redash_rd
+        #password: PG_TEST_DBRE_PWD # name of key Ref in redash secret
+        #dbname: test
+    ########### cassandra example ###########
+    #- name: preprod/dbre/cassandra-test
+      #type: Cassandra
+      #options:
+        #host: pg-test.dbre
+        #port: 9042
+        #username: redash_rd
+        #password: CASSANDRA_TEST_DBRE_PWD # name of key Ref in redash secret
+        #keyspace: test
+  #groups:
+    #- name: DBRE
+      #datasources:
+        #- preprod/dbre/mariadb-test
+        #- preprod/dbre/pg-test

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -29,6 +29,9 @@ volumes: []
 # volumeMounts -- Redash global volume mounts configuration - applied to all containers
 volumeMounts: []
 
+# commonLabels -- Redash global labels -- applied to all objects
+commonLabels: {}
+
 ## Service account and security context configuration
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -1,11 +1,11 @@
 ## Default values for Redash.
 
 image:
-  registry: docker.io
+  registry: eu.gcr.io/bbc-registry
   # image.repo -- Redash image name used for server and worker pods
-  repo: redash/preview
+  repo: redash
   # image.tag -- Redash image [tag](https://hub.docker.com/r/redash/redash/tags)
-  tag:
+  tag: 24.06.0-dev
   # image.pullPolicy - Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -659,6 +659,9 @@ redis:
   replica:
     replicaCount: 0
 
+istio:
+  outboundTrafficPolicy: REGISTRY_ONLY
+
 # extraObjects -- Additional kubernetes manifests to deploy alongside the chart. Useful to include external secrets for dependencies.
 extraObjects: []
 # - apiVersion: mumoshu.github.io/v1alpha1

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -208,7 +208,7 @@ redash:
   scheduledQueryTimeLimit: ""
   # -- `REDASH_ADHOC_QUERY_TIME_LIMIT` value. Time limit for adhoc queries (in seconds).
   # @default -- None
-  adhocQueryTimeLimit: ""
+  adhocQueryTimeLimit: 180
   # -- `REDASH_ENABLED_DESTINATIONS` value. Comma-separated list of alert destinations to be enabled (e.g. `redash.destinations.email,redash.destinations.slack` ).
   # @default -- ”,”.join(default_destinations)
   enabledDestinations: ""

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -331,7 +331,11 @@ server:
     failureThreshold: 3
 
   # server.podSecurityContext -- Security contexts for server pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-  podSecurityContext: {}
+  podSecurityContext:
+    # 1000 is the uid of the default redash user in the image
+    runAsUser: 1000
+    fsGroup: 1000
+    runAsGroup: 1000
   securityContext: {}
 
   # server.nodeSelector -- Node labels for server pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
@@ -426,7 +430,12 @@ worker:
     #  memory: 500Mi
 
   # worker.podSecurityContext -- Default worker's security context pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-  podSecurityContext: {}
+  podSecurityContext:
+    # 1000 is the uid of the default redash user in the image
+    runAsUser: 1000
+    fsGroup: 1000
+    runAsGroup: 1000
+
   securityContext: {}
 
   # worker.nodeSelector -- Default node labels for worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
@@ -540,7 +549,11 @@ migrations:
   #  memory: 500Mi
 
   # migrations.podSecurityContext -- Security contexts for scheduled worker pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-  podSecurityContext: {}
+  podSecurityContext:
+    # 1000 is the uid of the default redash user in the image
+    runAsUser: 1000
+    fsGroup: 1000
+    runAsGroup: 1000
   securityContext: {}
 
   # migrations.nodeSelector -- Node labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -572,7 +572,7 @@ externalPostgreSQLSecret:
 ## Configuration values for the postgresql dependency. This PostgreSQL instance is used by default for all Redash state storage [ref](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md)
 postgresql:
   # postgresql.enabled -- Whether to deploy a PostgreSQL server to satisfy the applications database requirements. To use an external PostgreSQL set this to false and configure the externalPostgreSQL parameter.
-  enabled: true
+  enabled: false
   primary:
     service:
       ports:
@@ -596,7 +596,7 @@ externalRedisSecret:
 ## Configuration values for the redis dependency. This Redis instance is used by default for caching and temporary storage [ref](https://github.com/bitnami/charts/blob/main/bitnami/redis/README.md)
 redis:
   # redis.enabled -- Whether to deploy a Redis server to satisfy the applications database requirements. To use an external Redis set this to false and configure the externalRedis parameter.
-  enabled: true
+  enabled: false
   database: 0
   master:
     service:

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -30,7 +30,10 @@ volumes: []
 volumeMounts: []
 
 # commonLabels -- Redash global labels -- applied to all objects
-commonLabels: {}
+commonLabels:
+  tags.datadoghq.com/service: "{{ .Release.Name | lower }}"
+  tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+  team: dbre
 
 ## Service account and security context configuration
 serviceAccount:
@@ -348,10 +351,15 @@ server:
   affinity: {}
 
   # server.podAnnotations -- Annotations for server pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
-  podAnnotations: {}
+  podAnnotations:
+    ad.datadoghq.com/redash-server.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+    ad.datadoghq.com/redash-server.init_configs: '[{}]'
 
   # server.podLabels -- Labels for server pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-  podLabels: {}
+  podLabels:
+    tags.datadoghq.com/service: "{{ .Release.Name | lower }}"
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    team: dbre
 
   # server.volumes -- Volumes for server pod assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/)
   volumes: []
@@ -401,16 +409,39 @@ workers:
     env:
       QUEUES: queries
       WORKERS_COUNT: 2
+    podAnnotations:
+      ad.datadoghq.com/redash-adhocworker.logs: >-
+        [{
+          "source": "redash",
+          "service": "{{ $.Release.Name }}",
+          "log_processing_rules": [{
+            "type": "exclude_at_match",
+            "name": "exclude_healthcheck",
+            "pattern" : "worker_healthcheck"
+          },
+          {
+            "type": "exclude_at_match",
+            "name": "exclude_info",
+            "pattern" : "info"
+          }]
+        }]
+      ad.datadoghq.com/redash-adhocworker.init_configs: '[{}]'
   scheduled:
     # workers.scheduled.env -- Redash scheduled worker specific environment variables.
     env:
       QUEUES: scheduled_queries,schemas
       WORKERS_COUNT: 1
+    podAnnotations:
+      ad.datadoghq.com/redash-scheduledworker.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+      ad.datadoghq.com/redash-scheduledworker.init_configs: '[{}]'
   generic:
     # workers.generic.env -- Redash generic worker specific environment variables.
     env:
       QUEUES: periodic,emails,default
       WORKERS_COUNT: 1
+    podAnnotations:
+      ad.datadoghq.com/redash-genericworker.logs: '[{"source": "redash", "service": "{{ $.Release.Name }}"}]'
+      ad.datadoghq.com/redash-genericworker.init_configs: '[{}]'
 
 ## Common worker configuration, which can be overidden for each worker at workers.<workerName>
 worker:
@@ -451,7 +482,10 @@ worker:
   podAnnotations: {}
 
   # worker.podLabels -- Default labels for worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-  podLabels: {}
+  podLabels:
+    tags.datadoghq.com/service: "{{ .Release.Name | lower }}"
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    team: dbre
 
   # worker.volumes -- Default volumes for pod worker assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/)
   volumes: []
@@ -518,7 +552,10 @@ scheduler:
   podAnnotations: {}
 
   # scheduler.podLabels -- Labels for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-  podLabels: {}
+  podLabels:
+    tags.datadoghq.com/service: "{{ .Release.Name | lower }}"
+    tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+    team: dbre
 
   # scheduler.volumes -- Volumes for scheduler pod  assignment [ref](https://kubernetes.io/docs/concepts/storage/volumes/)
   volumes: []
@@ -569,7 +606,9 @@ migrations:
   podAnnotations: {}
 
   # migrations.podLabels -- Labels for migration pod [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-  podLabels: {}
+  podLabels:
+    # Disable Istio side-car preventing job to finish properly
+    sidecar.istio.io/inject: "false"
 
 # externalPostgreSQL -- External PostgreSQL configuration. To use an external PostgreSQL instead of the automatically deployed postgresql chart: set postgresql.enabled to false then uncomment and configure the externalPostgreSQL connection URL (e.g. postgresql://user:pass@host:5432/database)
 externalPostgreSQL:

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -552,6 +552,9 @@ migrations:
   # migrations.podAnnotations -- Annotations for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
   podAnnotations: {}
 
+  # migrations.podLabels -- Labels for migration pod [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  podLabels: {}
+
 # externalPostgreSQL -- External PostgreSQL configuration. To use an external PostgreSQL instead of the automatically deployed postgresql chart: set postgresql.enabled to false then uncomment and configure the externalPostgreSQL connection URL (e.g. postgresql://user:pass@host:5432/database)
 externalPostgreSQL:
 # externalPostgreSQLSecret -- Read external PostgreSQL configuration from a secret. This should point at a secret file with a single key which specifies the connection string.


### PR DESCRIPTION
### What
This PR should *not* be merged, because we want to keep the branch as-is, since it's a fork of an upstream chart.
But it's just for review, so I still appreciate approvals :)
BTW, I recommend to read each commit one by one (much more readable).

Important: the 4 first commits are totally generic and I've also created a PR in the upstream project for these features (cf: PR 180 on https://github.com/getredash/contrib-helm-chart/pulls).
We'll rebase our fork above the upstream changes when merged (and maybe edited).

### Upgrade notes (from current fork):
1. Prepare a PR that modify the HR/GitRepo with several changes
    - update the path of the chart (from `.` to `charts/redash`, line 10 of the HR yaml) 
    - adapt the yaml structure: from `adhocWorker` + `scheduledWorker` to the new: `workers.adhoc` + `workers.scheduled`
    - and remove useless attributes: `images`, redis/pg enabled
3. `k delete deploy redash redash-adhocworker redash-genericworker redash-scheduledworker redash-scheduler` (because we're changing the label selector which is immutable)
4. merge PR
5. after new pod spawned: `k exec -ti deploy/redash -- /app/bin/docker-entrypoint manage db upgrade` 
6. Fix the SAML configuration (that seems to become stricter than before):
    - on **onelogin** (in `Configuration` page of the redash "app"): change the `Audience (EntityID)` value to the full URL of redash (`https://redash...../`)
    - and on **redash** HR: change the `redash.samlEntityId` value to the URL of redash (exactly the same than above)

DBRE-3978